### PR TITLE
Change to use bcrypt hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ These *must* be changed before you go into production, so you need to do the fol
 * Copy the demo configuration file above into your project. Make sure it is ignored by any version control systems.
 * Open it up in your favorite text editor.
 * Change the `admin_email` field to your email address
-* Change the `admin_password_hash` field to the SHA-256 hash of a password of your choice. Never use online services to create your hashes, but hashes created using [this service](http://www.xorbin.com/tools/sha256-hash-calculator) will work. Don't forget to append your `salt`.
+* Change the `admin_password_hash` field to the bcrypt hash of a password of your choice. Generate the hash using the bundled `minim-genhash` utility by invoking `vendor/bin/minim-genhash <password>` from the project root.
 * Change the `secret_key` field to a randomly-generated string at least 12 characters long.
 * Change the `salt` field to a randomly-generated string at least 12 characters long.
 * The default value of 32 for the `token_length` field should be okay for most applications.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ Minim will require you to create a configuration file that looks something like 
 # Don't commit this file to source control, it contains your secret settings.
 
 admin_email: me@example.com # The e-mail address of the user, used as a username.
-admin_password_hash: 8b2d49d3e1e9a339b030e08e89ed6cb77c50081e8f9e1c41511216b4d1787aef # The user's password hash.
-secret_key: 7WCPTI3of3cp # The secret key the application uses for symmetric encryption.
-salt: cgJ28CsaeV1T # The salt used to salt passwords before hashing.
+admin_password_hash: $2y$10$x8.kXrWv4lXFpObosuwQ0uoiQAUeFAlEL.oi0tN5pnM.72hoK9e8K # The user's password hash.
+secret_key: 7WCPTI3of3cp # The secret key the application uses for symmetric encryption
 token_length: 32 # The length, in bytes, of any generated authentication tokens.
 token_ttl: 1200 # The time to live for authentication tokens, in seconds.
 cookie_name: minim_auth # The name of the authentication cookie.

--- a/bin/minim-genhash
+++ b/bin/minim-genhash
@@ -1,0 +1,8 @@
+<?php
+
+require __DIR__ . '/../src/Encryption.php';
+
+use Minim\Encryption;
+
+// Output hashed password.
+echo 'Your password hash is: ' . Encryption::hash($argv[1]);

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "paragonie/random_compat": "^2.0",
         "ircmaxell/password-compat": "^1.0"
     },
+    "bin": ["bin/minim-genhash"],
     "autoload": {
         "psr-4": {
             "Minim\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": ">=5.3.0",
         "mustangostang/spyc": "^0.5.1",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": "^2.0",
+        "ircmaxell/password-compat": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,157 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "8123781080d579c041ec717efe711e39",
+    "packages": [
+        {
+            "name": "ircmaxell/password-compat",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/password_compat.git",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/password.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@php.net",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
+            "homepage": "https://github.com/ircmaxell/password_compat",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "time": "2014-11-20 16:49:30"
+        },
+        {
+            "name": "mustangostang/spyc",
+            "version": "0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mustangostang/spyc.git",
+                "reference": "dc4785b4d7227fd9905e086d499fb8abfadf9977"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mustangostang/spyc/zipball/dc4785b4d7227fd9905e086d499fb8abfadf9977",
+                "reference": "dc4785b4d7227fd9905e086d499fb8abfadf9977",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.5.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Spyc.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT License"
+            ],
+            "authors": [
+                {
+                    "name": "mustangostang",
+                    "email": "vlad.andersen@gmail.com"
+                }
+            ],
+            "description": "A simple YAML loader/dumper class for PHP",
+            "homepage": "https://github.com/mustangostang/spyc/",
+            "keywords": [
+                "spyc",
+                "yaml",
+                "yml"
+            ],
+            "time": "2013-02-21 10:52:01"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2016-04-03 06:00:07"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}

--- a/src/Authenticator.php
+++ b/src/Authenticator.php
@@ -114,7 +114,7 @@ class Authenticator
 
         // Check credentials.
         if ($this->config->getAdminEmail() != $email
-            || Encryption::sha256($password, $this->config->getSalt()) != $this->config->getAdminPasswordHash())
+            || !Encryption::verify($password, $this->config->getAdminPasswordHash()))
         {
             return false; // Authentication failure.
         }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -56,16 +56,6 @@ class Configuration
     }
 
     /**
-     * Gets the salt to use during password hashing.
-     *
-     * @return string
-     */
-    public function getSalt()
-    {
-        return $this->config['salt'];
-    }
-
-    /**
      * Gets the length configured for login tokens.
      *
      * @return int

--- a/src/Encryption.php
+++ b/src/Encryption.php
@@ -12,15 +12,26 @@ namespace Minim;
 class Encryption
 {
     /**
-     * Hashes a password using SHA-256.
+     * Hashes a password.
      *
      * @param string $password  the password to hash
-     * @param string $salt      the salt for the password
      * @return string
      */
-    public static function sha256($password, $salt)
+    public static function hash($password)
     {
-        return hash('sha256', $password . $salt);
+        return password_hash($password, PASSWORD_DEFAULT);
+    }
+
+    /**
+     * Verifies that a password matches a hash.
+     *
+     * @param $password the password to verify
+     * @param $hash     the hash to check against
+     * @return bool
+     */
+    public static function verify($password, $hash)
+    {
+        return password_verify($password, $hash);
     }
 
     /**


### PR DESCRIPTION
Further to a suggestion by @alanpearce on #1 to use bcrypt for hashing instead of SHA-256. Seems a lot more secure with the configurable work factor and different hash/cryptographically secure salt for each generated password, all bundled in to one string.

I've left things as default for now, using `PASSWORD_DEFAULT` for the `$algo` parameter and letting PHP do the work with regard to generating a secure random salt and choosing a suitable work factor (I believe the defaullt is `10`).

Default credentials are unchanged.
